### PR TITLE
Optional installation of ThemisPP and Themis JNI

### DIFF
--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -91,5 +91,19 @@ class Libthemis < Formula
       system ENV.cxx, 'test.cpp', '-o', 'test-cpp', "-I#{include}", "-L#{lib}", '-lthemis'
       system './test-cpp'
     end
+    if build.with? 'java'
+      (testpath/'Test.java').write <<~EOF
+        public class Test {
+            static {
+                System.loadLibrary("themis_jni");
+            }
+            public static void main(String[] args) {
+                // Just check that the library has loaded.
+            }
+        }
+      EOF
+      system 'javac', 'Test.java'
+      system 'java', "-Djava.library.path=#{lib}", 'Test'
+    end
   end
 end

--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -7,12 +7,17 @@ class Libthemis < Formula
 
   depends_on 'openssl'
 
+  option 'with-cpp', 'Install C++ header files for ThemisPP'
+
   def install
     ENV['ENGINE'] = 'openssl'
     ENV['ENGINE_INCLUDE_PATH'] = Formula['openssl'].include
     ENV['ENGINE_LIB_PATH'] = Formula['openssl'].lib
     ENV['PREFIX'] = prefix
     system 'make', 'install'
+    if build.with? 'cpp'
+      system 'make', 'themispp_install'
+    end
   end
 
   test do

--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -77,5 +77,19 @@ class Libthemis < Formula
     EOF
     system ENV.cc, 'test.c', '-o', 'test', "-I#{include}", "-L#{lib}", '-lthemis'
     system './test'
+    if build.with? 'cpp'
+      (testpath/'test.cpp').write <<~EOF
+        #include <themispp/secure_keygen.hpp>
+
+        int main(void)
+        {
+            themispp::secure_key_pair_generator_t<themispp::EC> keys;
+
+            return EXIT_SUCCESS;
+        }
+      EOF
+      system ENV.cxx, 'test.cpp', '-o', 'test-cpp', "-I#{include}", "-L#{lib}", '-lthemis'
+      system './test-cpp'
+    end
   end
 end

--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -24,6 +24,37 @@ class Libthemis < Formula
     end
   end
 
+  def caveats
+    if build.with? 'java'
+      themis_jni_lib = 'libthemis_jni.dylib'
+      java_library_paths = `
+        java -XshowSettings:properties -version 2>&1 \
+        | sed -E 's/^ +[^=]+ =/_&/' \
+        | awk -v prop=java.library.path \
+          'BEGIN { RS = "_"; IFS = " = " }
+           { if($1 ~ prop) {
+               for (i = 3; i <= NF; i++) {
+                 print $i
+               }
+             }
+           }'
+      `
+      <<~EOF
+        Most Java installations do not include Homebrew directories into library
+        search path. Here is current "java.library.path" in your system:
+
+        #{java_library_paths.split("\n").map{|s| '    ' + s}.join("\n")}
+
+        #{themis_jni_lib} has been installed into #{lib}.
+        Make sure to either add #{lib} to "java.library.path",
+        or move #{themis_jni_lib} to a location known by Java.
+
+        Read more: https://docs.cossacklabs.com/pages/java-and-android-howto/
+
+      EOF
+    end
+  end
+
   test do
     (testpath/'test.c').write <<~EOF
       #include <themis/themis.h>

--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -8,6 +8,7 @@ class Libthemis < Formula
   depends_on 'openssl'
 
   option 'with-cpp', 'Install C++ header files for ThemisPP'
+  option 'with-java', 'Install JNI library for JavaThemis'
 
   def install
     ENV['ENGINE'] = 'openssl'
@@ -17,6 +18,9 @@ class Libthemis < Formula
     system 'make', 'install'
     if build.with? 'cpp'
       system 'make', 'themispp_install'
+    end
+    if build.with? 'java'
+      system 'make', 'themis_jni_install'
     end
   end
 


### PR DESCRIPTION
Add support for installing JavaThemis via package managers. JavaThemis needs JNI library so let’s make it available. While we’re here, let’s make ThemisPP available as well.

**Install ThemisPP `--with-cpp`**

Add an option to install ThemisPP support when installing Themis. Options are frowned upon in the main Homebrew repository, but we're not there. It would be a waste to have two separate packages that download the same source tarball. In case of ThemisPP we don’t even need to compile anything, that's just copying C++ headers (and you need to install Themis Core for them anyway).

**Install Themis JNI `--with-java`**

Another option to install Themis JNI library which requires Themis Core to operate. Now we do need to compile something.

Java is not available as Homebrew package in the main repo. However, it's possible to install it via Casks. Unfortunately, we cannot depend on casks, so it's assumed that the system has Java installed when using the `--with-java` option.

Currently Themis JNI library is tightly coupled with the core library so they have to compiled together using the same private header files. Therefore we use options, not a separate package.

**Warn about JNI installation path**

Unfortunately for macOS, Homebrew is not able to install Themis JNI library into any location accessible to Java by default. Usually the following locations are used by Oracle Java:

| **Directory** | **Why unusable** |
| - | - |
|`$HOME/Library/Java/Extensions`|should not write here|
|`/Library/Java/Extensions`|requires root access|
|`/Network/Library/Java/Extensions`|protected by SIP|
|`/System/Library/Java/Extensions`|protected by SIP|
|`/usr/lib/java`|protected by SIP|
|`$PWD`|should not write here|

Homebrew does not support running with root access. We'd need to have a proper macOS installer in order to write to /Library. Other locations are either inaccessible due to SIP or unrealistic. "This is life".

Therefore, print a warning for the user who will likely need to set up their application build properly in order to use the Themis Java.

The magic spell to print `java.library.path` is taken from the main Themis makefile.

**Test ThemisPP installation**

Just a simple test for ThemisPP, making sure that the library is accessible and the headers are visible in the system.

**Test Themis JNI installation**

Now we test Themis JNI library installation. This library is not intended to be used separately, so we don't test the API. We only need to make sure that it can be loaded by Java. Note how we setup "java.library.path" for that.