### PR TITLE
Update documentation URL

### DIFF
--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -49,7 +49,8 @@ class Libthemis < Formula
         Make sure to either add #{lib} to "java.library.path",
         or move #{themis_jni_lib} to a location known by Java.
 
-        Read more: https://docs.cossacklabs.com/pages/java-and-android-howto/
+        Read more:
+        https://docs.cossacklabs.com/themis/languages/java/installation-desktop/#installing-stable-version-on-macos
 
       EOF
     end


### PR DESCRIPTION
Save us a redirect and point the users to the correct location. (Right now the docs don't explain much more that you already see in the message above, but hey...)

Also, put the (long) URL on its own line to make it easier to copy.