### PR TITLE
Require OpenSSL 1.1

### DIFF
--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -5,15 +5,15 @@ class Libthemis < Formula
   url 'https://github.com/cossacklabs/themis/archive/<%CL_THEMIS_VERSION%>.tar.gz'
   sha256 '<%CL_THEMIS_GITHUB_TARGZ_SHA256%>'
 
-  depends_on 'openssl'
+  depends_on 'openssl@1.1'
 
   option 'with-cpp', 'Install C++ header files for ThemisPP'
   option 'with-java', 'Install JNI library for JavaThemis'
 
   def install
     ENV['ENGINE'] = 'openssl'
-    ENV['ENGINE_INCLUDE_PATH'] = Formula['openssl'].include
-    ENV['ENGINE_LIB_PATH'] = Formula['openssl'].lib
+    ENV['ENGINE_INCLUDE_PATH'] = Formula['openssl@1.1'].include
+    ENV['ENGINE_LIB_PATH'] = Formula['openssl@1.1'].lib
     ENV['PREFIX'] = prefix
     system 'make', 'install'
     if build.with? 'cpp'

--- a/.cicd/Formula.templates/libthemis.rb
+++ b/.cicd/Formula.templates/libthemis.rb
@@ -4,6 +4,8 @@ class Libthemis < Formula
   head 'https://github.com/cossacklabs/themis.git'
   url 'https://github.com/cossacklabs/themis/archive/<%CL_THEMIS_VERSION%>.tar.gz'
   sha256 '<%CL_THEMIS_GITHUB_TARGZ_SHA256%>'
+  version '<%CL_THEMIS_VERSION%>'
+  revision <%CL_LIBTHEMIS_REVISION%>
 
   depends_on 'openssl@1.1'
 

--- a/.cicd/project_release.sh
+++ b/.cicd/project_release.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 projectrelease_help() {
     echo "
 Usage:
-    $(basename $0) --project <PROJECT> --version <VERSION>
+    $(basename $0) --project <PROJECT> --version <VERSION> [--revision <REVISION>]
 
     --project <PROJECT>     update files of PROJECT, one of:
 $(
@@ -17,6 +17,9 @@ done
 
     --version <VERSION>     generate Homebrew files for specified VERSION in
                             SemVer2 format, equal to appropriate GitHub tag
+
+    --revision <REVISION>   specify optional Homebrew formula revision,
+                            defaults to 0
 
 Description:
     This script generates Homebrew files for the new version of the specified
@@ -54,6 +57,15 @@ projectrelease_parse_args() {
                 version="$1"
                 shift
                 ;;
+            (--revision)
+                [[ -n "${1:-}" ]] || projectrelease_raise \
+                    "revision must be present next to --revision option."
+                [[ "$1" =~ ^[0-9]+$ ]] || \
+                    projectrelease_raise \
+                        "incorrect revision format '$1'. integer expected."
+                revision="$1"
+                shift
+                ;;
             (help|--help|-?|--?)
                 projectrelease_help
                 exit 0
@@ -68,6 +80,7 @@ projectrelease_parse_args() {
         projectrelease_help
         exit 1
     fi
+    revision=${revision:-0}
 }
 
 
@@ -94,6 +107,7 @@ projectrelease_main() {
 
     sed -i "s/<%CL_THEMIS_VERSION%>/$version/g" "${TMP_DIR}/${project}.rb"
     sed -i "s/<%CL_THEMIS_GITHUB_TARGZ_SHA256%>/$sha256/g" "${TMP_DIR}/${project}.rb"
+    sed -i "s/<%CL_LIBTHEMIS_REVISION%>/$revision/g" "${TMP_DIR}/${project}.rb"
 
     cp -f "${TMP_DIR}/${project}.rb" "${BASE_DIR}/../Formula/${project}.rb"
 


### PR DESCRIPTION
While Themis can apparently build against OpenSSL 3.0 without errors, there is something not quite right with the way we use OpenSSL API and some unit tests fail. OpenSSL 3.0 is not a fully support cryptographic engine yet, so let's play it safe and explicitly request OpenSSL 1.1.

When publishing the updated formula it would be nice to bump the `revision` to 1 so that people having previous default revision 0 will know that this is a viable upgrade. I have (hopefully) taught the templating script to accept a new, optional parameter `--revision` which can be used to set this value automatically.

I'm not sure how exactly that's handled so I'll leave it to @shadinua vOv